### PR TITLE
Add Super-related content: GPIO, 4xMipi CSI, Dual Ethernet, and Chassis Extension

### DIFF
--- a/3-Basic-Tools-and-Getting-Started/3.32-Super-GPIO/README.md
+++ b/3-Basic-Tools-and-Getting-Started/3.32-Super-GPIO/README.md
@@ -1,0 +1,102 @@
+# 3.32 Super GPIO
+
+> [!IMPORTANT]
+> This page is intended for the Seeed `reComputer Super` carrier-board family, such as [`reComputer Super J4011`](https://www.seeedstudio.com/reComputer-Super-J401-Carrier-Board-p-6642.html). The 40-pin header layout and pin behavior are board-specific and should not be assumed to match other Jetson carrier boards.
+
+## Introduction
+
+GPIO stands for General Purpose Input/Output. These pins let software read external digital signals or drive simple peripherals such as LEDs, buttons, buzzers, and control lines. The reComputer Super features a 40-pin extension header that provides access to GPIO pins, allowing for easy integration with external devices.
+
+## Hardware Connection
+
+The reComputer Super features a 40-pin extension header that provides access to GPIO pins. To use the GPIO pins, you need to connect external devices to the appropriate pins on this header.
+
+## GPIO Library Installation
+
+The `Jetson.GPIO` library is required to work with GPIO pins on the reComputer Super. If you haven't installed it yet, you can do so by following the instructions in [3.27 Installing the GPIO Library](../3.27-Installing-the-GPIO-Library/README.md).
+
+## Numbering Modes
+
+The `Jetson.GPIO` library supports two common numbering schemes:
+
+| Mode | Description | Typical Use |
+| --- | --- | --- |
+| `BOARD` | Numbers pins by their physical location on the 40-pin header | Best when you are wiring directly from the header silkscreen or a pinout diagram |
+| `BCM` | Numbers pins by the GPIO mapping used by the library | Best when you are following Python GPIO examples that refer to logical GPIO IDs |
+
+## GPIO Usage Examples
+
+### Basic GPIO Output
+
+```python
+import Jetson.GPIO as GPIO
+import time
+
+# Set GPIO mode
+GPIO.setmode(GPIO.BOARD)
+
+# Define pin
+output_pin = 12
+
+# Set up the pin
+GPIO.setup(output_pin, GPIO.OUT)
+
+try:
+    while True:
+        # Turn on the pin
+        GPIO.output(output_pin, GPIO.HIGH)
+        time.sleep(1)
+        # Turn off the pin
+        GPIO.output(output_pin, GPIO.LOW)
+        time.sleep(1)
+except KeyboardInterrupt:
+    # Clean up
+    GPIO.cleanup()
+```
+
+### Basic GPIO Input
+
+```python
+import Jetson.GPIO as GPIO
+import time
+
+# Set GPIO mode
+GPIO.setmode(GPIO.BOARD)
+
+# Define pin
+input_pin = 11
+
+# Set up the pin
+GPIO.setup(input_pin, GPIO.IN)
+
+try:
+    while True:
+        # Read the pin value
+        value = GPIO.input(input_pin)
+        print(f"Pin value: {value}")
+        time.sleep(0.5)
+except KeyboardInterrupt:
+    # Clean up
+    GPIO.cleanup()
+```
+
+## Super-Specific GPIO Features
+
+The reComputer Super's 40-pin header provides access to a range of GPIO pins, allowing for flexible integration with external devices. This makes it ideal for a variety of applications, including:
+
+- Controlling LEDs and other indicators
+- Reading button presses and sensor inputs
+- Controlling motors and actuators
+- Interfacing with other microcontrollers and devices
+
+## Safety Precautions
+
+- Always double-check pin connections before applying power
+- Use appropriate resistors when connecting LEDs and other components
+- Avoid short-circuiting GPIO pins
+- Be mindful of the maximum current rating for GPIO pins
+
+## Further Reading
+
+- [Jetson.GPIO Library Documentation](https://github.com/NVIDIA/jetson-gpio)
+- [reComputer Super Hardware and Interfaces Usage](https://wiki.seeedstudio.com/recomputer_jetson_super_hardware_interfaces_usage/)

--- a/3-Basic-Tools-and-Getting-Started/3.33-Super-4xMipi-CSI/README.md
+++ b/3-Basic-Tools-and-Getting-Started/3.33-Super-4xMipi-CSI/README.md
@@ -1,0 +1,116 @@
+# 3.33 Super 4xMipi CSI
+
+> [!IMPORTANT]
+> This page is intended for the Seeed `reComputer Super` carrier-board family, such as [`reComputer Super J4011`](https://www.seeedstudio.com/reComputer-Super-J401-Carrier-Board-p-6642.html). The CSI connector count, camera orientation, and supported sensor overlays are specific to the Super family.
+
+## Introduction
+
+The reComputer Super features 4x MIPI CSI (Camera Serial Interface) ports, allowing you to connect up to 4 CSI cameras simultaneously. This makes it ideal for multi-camera applications such as 360-degree vision, stereo vision, and multi-angle object tracking.
+
+## Hardware Requirements
+
+- reComputer Super with JetPack 6.2 installed
+- Compatible MIPI CSI cameras (up to 4)
+- CSI ribbon cables
+
+## Hardware Connection
+
+### Step 1: Power off the Device
+
+Before connecting or disconnecting CSI cameras, ensure the reComputer Super is powered off to avoid damage.
+
+### Step 2: Open the Back Cover
+
+Open the back cover of the reComputer Super to access the CSI ports.
+
+### Step 3: Connect the Cameras
+
+Connect the MIPI CSI cameras to the appropriate CSI ports on the reComputer Super board. Ensure the connections are firm and properly seated.
+
+### Step 4: Secure the Cameras
+
+Secure the cameras and ensure all connections are properly tightened.
+
+## Enable the CSI Cameras
+
+### Step 1: Check Camera Recognition
+
+After powering on the device, open a terminal and check if the cameras are recognized:
+
+```bash
+ls /dev/video*
+```
+
+### Step 2: Install Video Utilities (if needed)
+
+If not already present, install video utilities:
+
+```bash
+sudo apt install v4l-utils
+```
+
+## Preview the Cameras
+
+### Preview a Single Camera
+
+Use `nvgstcapture-1.0` to preview the CSI stream from a specific camera:
+
+```bash
+nvgstcapture-1.0 --sensor-id=0
+```
+
+### Preview Multiple Cameras
+
+To preview a different camera, change the `--sensor-id` parameter:
+
+```bash
+nvgstcapture-1.0 --sensor-id=1  # For the second camera
+nvgstcapture-1.0 --sensor-id=2  # For the third camera
+nvgstcapture-1.0 --sensor-id=3  # For the fourth camera
+```
+
+## Common Preview Options
+
+### Specify Resolution
+
+You can specify a custom preview resolution:
+
+```bash
+nvgstcapture-1.0 --sensor-id=0 --cus-prev-res=1280x720
+```
+
+### Capture Images
+
+To capture an image, press the `c` key while in the preview window.
+
+### Record Video
+
+To start recording video, press the `r` key while in the preview window.
+
+## Multi-Camera Applications
+
+The reComputer Super's 4x CSI ports enable a variety of multi-camera applications:
+
+- **360-degree vision**: Use four cameras to capture a complete view of the surroundings
+- **Stereo vision**: Use two cameras for depth perception and 3D reconstruction
+- **Multi-angle object tracking**: Track objects from multiple perspectives
+- **Simultaneous surveillance**: Monitor multiple areas at once
+
+## Troubleshooting
+
+### Camera Not Recognized
+
+- Ensure the camera is properly connected
+- Check that the camera driver is installed
+- Verify that the camera is compatible with JetPack 6.2
+
+### Poor Image Quality
+
+- Ensure the camera lens is clean
+- Adjust the camera focus if necessary
+- Check for proper lighting conditions
+
+## Further Reading
+
+- [reComputer Super Hardware and Interfaces Usage](https://wiki.seeedstudio.com/recomputer_jetson_super_hardware_interfaces_usage/)
+- [NVIDIA Jetson Camera Documentation](https://developer.nvidia.com/embedded/learn/tutorials/first-picture-csi-camera)

--- a/3-Basic-Tools-and-Getting-Started/3.34-Super-Dual-Ethernet/README.md
+++ b/3-Basic-Tools-and-Getting-Started/3.34-Super-Dual-Ethernet/README.md
@@ -1,0 +1,109 @@
+# 3.34 Super Dual Ethernet
+
+> [!IMPORTANT]
+> This page is intended for the Seeed `reComputer Super` carrier-board family, such as [`reComputer Super J4011`](https://www.seeedstudio.com/reComputer-Super-J401-Carrier-Board-p-6642.html). The dual Ethernet configuration is specific to the Super family.
+
+## Introduction
+
+The reComputer Super features dual RJ45 Gigabit Ethernet ports, providing high-speed networking capabilities. This dual Ethernet configuration enables a variety of advanced networking scenarios, such as network redundancy, load balancing, and segmentation.
+
+## Hardware Overview
+
+The reComputer Super is equipped with two Gigabit Ethernet ports, allowing for flexible network configurations:
+
+- **Port 1**: Primary Ethernet port
+- **Port 2**: Secondary Ethernet port
+
+## Basic Network Configuration
+
+### Check Network Interfaces
+
+To view the available network interfaces, open a terminal and run:
+
+```bash
+ifconfig
+```
+
+You should see two Ethernet interfaces, typically named `eth0` and `eth1`.
+
+### Configure Network Settings
+
+You can configure network settings through the Ubuntu desktop interface or via the command line.
+
+#### Via Desktop Interface
+
+1. Click on the network icon in the top-right corner
+2. Select "Wired Settings"
+3. Click on the gear icon next to each Ethernet connection to configure settings
+
+#### Via Command Line
+
+To configure network settings via the command line, you can edit the netplan configuration file:
+
+```bash
+sudo nano /etc/netplan/01-network-manager-all.yaml
+```
+
+## Advanced Network Scenarios
+
+### Network Redundancy
+
+Configure both Ethernet ports to connect to the same network for redundancy. If one port fails, the other will continue to provide network connectivity.
+
+### Network Segmentation
+
+Use the dual Ethernet ports to connect to different networks:
+
+- **Port 1**: Connect to the internal network for management
+- **Port 2**: Connect to an external network for data transfer
+
+### Load Balancing
+
+Configure both Ethernet ports to work together for increased bandwidth and load balancing.
+
+### Network Address Translation (NAT)
+
+Use one Ethernet port as the WAN interface and the other as the LAN interface to create a NAT gateway.
+
+## Network Performance Testing
+
+### Test Network Speed
+
+Use `iperf3` to test network performance:
+
+1. Install iperf3:
+
+```bash
+sudo apt install iperf3
+```
+
+2. On the server side:
+
+```bash
+iperf3 -s
+```
+
+3. On the client side:
+
+```bash
+iperf3 -c <server-ip>
+```
+
+## Troubleshooting
+
+### Ethernet Port Not Detected
+
+- Ensure the Ethernet cable is properly connected
+- Check that the network cable is functional
+- Verify that the network driver is installed
+
+### Slow Network Speed
+
+- Check for network congestion
+- Verify that you're using Cat5e or Cat6 cables for Gigabit speeds
+- Ensure the network switch supports Gigabit Ethernet
+
+## Further Reading
+
+- [reComputer Super Hardware and Interfaces Usage](https://wiki.seeedstudio.com/recomputer_jetson_super_hardware_interfaces_usage/)
+- [Ubuntu Network Configuration Documentation](https://help.ubuntu.com/community/NetworkConfiguration)

--- a/3-Basic-Tools-and-Getting-Started/3.35-Super-Chassis-Extension/README.md
+++ b/3-Basic-Tools-and-Getting-Started/3.35-Super-Chassis-Extension/README.md
@@ -1,0 +1,70 @@
+# 3.35 Super Chassis Extension
+
+> [!IMPORTANT]
+> This page is intended for the Seeed `reComputer Super` carrier-board family, such as [`reComputer Super J4011`](https://www.seeedstudio.com/reComputer-Super-J401-Carrier-Board-p-6642.html). The chassis extension scenarios are under development and will be updated in future releases.
+
+## Introduction
+
+The reComputer Super's compact form factor and rich interface set make it an ideal candidate for various chassis extension scenarios. This document provides preliminary reference suggestions for chassis extension, with detailed implementations to be updated in future releases.
+
+## Reference Suggestions
+
+### 1. Mobile Robot Chassis
+
+- **Overview**: Integrate the reComputer Super into a mobile robot chassis for autonomous navigation and environmental perception
+- **Key Components**: 
+  - Mobile robot platform with motors and encoders
+  - LiDAR sensor for SLAM and obstacle detection
+  - IMU for localization
+  - 4x CSI cameras for visual navigation and object recognition
+- **Potential Applications**: 
+  - Autonomous delivery robots
+  - Inspection robots
+  - Educational robots
+
+### 2. Edge AI Gateway Chassis
+
+- **Overview**: Design a dedicated chassis for edge AI gateway applications
+- **Key Components**: 
+  - Dual Ethernet for network segmentation
+  - M.2 Key E for Wi-Fi/5G connectivity
+  - M.2 Key M for high-speed storage
+  - DIN rail mounting for industrial environments
+- **Potential Applications**: 
+  - Smart factory edge gateways
+  - Intelligent video surveillance systems
+  - IoT edge computing nodes
+
+### 3. Autonomous Vehicle Chassis
+
+- **Overview**: Integrate the reComputer Super into small-scale autonomous vehicles
+- **Key Components**: 
+  - 4x CSI cameras for 360-degree vision
+  - LiDAR for precise distance measurement
+  - CAN bus interface for vehicle control
+  - GNSS receiver for positioning
+- **Potential Applications**: 
+  - Autonomous golf carts
+  - Campus shuttles
+  - Agricultural vehicles
+
+### 4. Industrial Control Chassis
+
+- **Overview**: Develop an industrial control chassis for factory automation
+- **Key Components**: 
+  - Dual Ethernet for redundant communication
+  - CAN bus for industrial device integration
+  - GPIO for sensor and actuator control
+  - Fanless design for harsh environments
+- **Potential Applications**: 
+  - Factory automation control systems
+  - Process monitoring stations
+  - Quality inspection systems
+
+## Future Updates
+
+This document provides preliminary reference suggestions for reComputer Super chassis extension scenarios. Detailed implementation guides, including hardware designs, software configurations, and example code, will be updated in future releases. Stay tuned for more comprehensive information on chassis extension possibilities for the reComputer Super.
+
+## Contact and Feedback
+
+If you have any questions or suggestions regarding reComputer Super chassis extension scenarios, please feel free to contact Seeed Studio through our [official website](https://www.seeedstudio.com/) or [GitHub repository](https://github.com/Seeed-Projects/reComputer-Jetson-for-Beginners).

--- a/3-Basic-Tools-and-Getting-Started/README.MD
+++ b/3-Basic-Tools-and-Getting-Started/README.MD
@@ -25,6 +25,20 @@ Module 3 now serves as the unified entry point for Jetson beginner tooling. It k
 | Module 3.19 |             **[VS Code](./3.19-VS-Code/README.md)**             |
 | Module 3.20 |           **[JupyterLab](./3.20-JupyterLab/README.md)**            |
 | Module 3.21 | **[uv Python Environment Manager](./3.21-uv-Python-Environment-Manager/README.md)** |
+| Module 3.22 | **[Wi-Fi Adapter](./3.22-Wi-Fi-Adapter/README.md)** |
+| Module 3.23 | **[SSD Expansion](./3.23-SSD-Expansion/README.md)** |
+| Module 3.24 | **[CSI Camera](./3.24-CSI-Camera/README.md)** |
+| Module 3.25 | **[USB Camera](./3.25-USB-Camera/README.md)** |
+| Module 3.26 | **[GPIO Basics](./3.26-GPIO-Basics/README.md)** |
+| Module 3.27 | **[Installing the GPIO Library](./3.27-Installing-the-GPIO-Library/README.md)** |
+| Module 3.28 | **[GPIO Input](./3.28-GPIO-Input/README.md)** |
+| Module 3.29 | **[GPIO Output](./3.29-GPIO-Output/README.md)** |
+| Module 3.30 | **[UART Serial Communication](./3.30-UART-Serial-Communication/README.md)** |
+| Module 3.31 | **[I2C Communication](./3.31-I2C-Communication/README.md)** |
+| Module 3.32 | **[Super GPIO](./3.32-Super-GPIO/README.md)** |
+| Module 3.33 | **[Super 4xMipi CSI](./3.33-Super-4xMipi-CSI/README.md)** |
+| Module 3.34 | **[Super Dual Ethernet](./3.34-Super-Dual-Ethernet/README.md)** |
+| Module 3.35 | **[Super Chassis Extension](./3.35-Super-Chassis-Extension/README.md)** |
 
 ## Beginner Topic Coverage
 


### PR DESCRIPTION
## Changes
This PR adds Super-related content to the reComputer Jetson for Beginners guide:

- Added Super GPIO documentation (3.32)
- Added Super 4xMipi CSI documentation (3.33)
- Added Super Dual Ethernet documentation (3.34)
- Added Super Chassis Extension documentation (3.35)
- Updated Module 3 table of contents

All content is based on the official Seeed Studio documentation:
- https://wiki.seeedstudio.com/recomputer_jetson_super_getting_started/
- https://wiki.seeedstudio.com/recomputer_jetson_super_hardware_interfaces_usage/